### PR TITLE
Show diff even with missing approved file

### DIFF
--- a/lib/approvals/cli.rb
+++ b/lib/approvals/cli.rb
@@ -4,7 +4,7 @@ module Approvals
   class CLI < Thor
 
     desc "verify", "Go through all failing approvals with a diff tool"
-    method_option :diff, :type => :string, :default => 'diff', :aliases => '-d', :desc => 'The difftool to use. e.g. opendiff, vimdiff, etc.'
+    method_option :diff, :type => :string, :default => 'diff -N', :aliases => '-d', :desc => 'The difftool to use. e.g. opendiff, vimdiff, etc.'
     method_option :ask, :type => :boolean, :default => true, :aliases => "-a", :desc => 'Offer to approve the received file for you.'
     def verify
       approvals = File.read('.approvals').split("\n")


### PR DESCRIPTION
* Use `diff -N` by default, which will treat missing files as having
  no content.  This makes it easier to see the new golden master before
  approving it.