### PR TITLE
When verifying, print the names of the files being compared

### DIFF
--- a/lib/approvals/cli.rb
+++ b/lib/approvals/cli.rb
@@ -11,6 +11,7 @@ module Approvals
 
       rejected = []
       approvals.each do |approval|
+        puts "Comparing #{approval}"
         system("#{options[:diff]} #{approval}")
 
         if options[:ask] && yes?("Approve? [y/N] ")

--- a/lib/approvals/cli.rb
+++ b/lib/approvals/cli.rb
@@ -11,8 +11,9 @@ module Approvals
 
       rejected = []
       approvals.each do |approval|
-        puts "Comparing #{approval}"
-        system("#{options[:diff]} #{approval}")
+        diff_command = "#{options[:diff]} #{approval}"
+        puts diff_command
+        system(diff_command)
 
         if options[:ask] && yes?("Approve? [y/N] ")
           system("mv #{approval}")


### PR DESCRIPTION
This is very useful when you have multiple approvals to re-verify.
Otherwise, it's hard to know what you're looking at.