### PR TITLE
Don't show file not found message when .approvals is missing

### DIFF
--- a/lib/approvals/dotfile.rb
+++ b/lib/approvals/dotfile.rb
@@ -20,7 +20,7 @@ module Approvals
       end
 
       def includes?(text)
-        system("cat #{path} | grep -q \"^#{text}$\"")
+        system("cat #{path} 2> /dev/null | grep -q \"^#{text}$\"")
       end
 
       def write(text)


### PR DESCRIPTION
When first running approvals tests, there is no `.approvals` file and
the message `cat: /path/to/.approvals: No such file or directory` is
displayed.

This commit hides that message by redirecting the output of `cat` to
`/dev/null`.