### PR TITLE
Reverse the order of diffed files when verifying

### DIFF
--- a/lib/approvals/approval.rb
+++ b/lib/approvals/approval.rb
@@ -86,7 +86,7 @@ module Approvals
     end
 
     def diff_path
-      "#{received_path} #{approved_path}"
+      "#{approved_path} #{received_path}"
     end
 
     def full_path(state)

--- a/lib/approvals/cli.rb
+++ b/lib/approvals/cli.rb
@@ -11,13 +11,13 @@ module Approvals
 
       rejected = []
       approvals.each do |approval|
-        received, approved = *approval.split
-        diff_command = "#{options[:diff]} #{approved} #{received}"
+        diff_command = "#{options[:diff]} #{approval}"
         puts diff_command
         system(diff_command)
 
         if options[:ask] && yes?("Approve? [y/N] ")
-          system("mv #{approval}")
+          approved, received = *approval.split
+          system("mv #{received} #{approved}")
         else
           rejected << approval
         end

--- a/lib/approvals/cli.rb
+++ b/lib/approvals/cli.rb
@@ -11,7 +11,8 @@ module Approvals
 
       rejected = []
       approvals.each do |approval|
-        system("#{options[:diff]} #{approval}")
+        received, approved = *approval.split
+        system("#{options[:diff]} #{approved} #{received}")
 
         if options[:ask] && yes?("Approve? [y/N] ")
           system("mv #{approval}")


### PR DESCRIPTION
When diffing the received and approved files during verification, put
the `approved` file first so that the diff shows what would change if
the `received` file was approved as the new golden master.  This seems
clearer and easier to understand.

* This change will also need to be made to https://github.com/kytrinyx/approvals/pull/59

* This code would not handle filenames with embedded spaces.  However,
  the existing code also suffers from the same problems.  The `diff` and
  `mv` commands would fail with such filenames.

* A better implementation might be to change the order of the filenames
  in the `.approvals` file itself.  I'd be happy to re-submit this PR
  with that implementation instead.