### PR TITLE
Replace deprecated File.exists? with File.exist?

### DIFF
--- a/lib/approvals/approval.rb
+++ b/lib/approvals/approval.rb
@@ -35,7 +35,7 @@ module Approvals
     end
 
     def verify
-      unless File.exists?(namer.output_dir)
+      unless File.exist?(namer.output_dir)
         FileUtils.mkdir_p(namer.output_dir)
       end
 
@@ -57,11 +57,11 @@ module Approvals
     end
 
     def approved?
-      File.exists? approved_path
+      File.exist? approved_path
     end
 
     BINARY_FORMATS = [:binary]
-    
+
     def received_matches?
       if BINARY_FORMATS.include?(@format) # Read without ERB
         IO.read(received_path).chomp == IO.read(approved_path).chomp

--- a/lib/approvals/dotfile.rb
+++ b/lib/approvals/dotfile.rb
@@ -4,7 +4,7 @@ module Approvals
     class << self
 
       def reset
-        File.truncate(path, 0) if File.exists?(path)
+        File.truncate(path, 0) if File.exist?(path)
       end
 
       def append(text)


### PR DESCRIPTION
According to the docs for 2.2.0 (http://ruby-doc.org/core-2.2.0/File.html#method-c-exist-3F)  ```File.exists?``` has been deprecated and we should use ```File.exist?```. 

Looking all the way back to 1.8.7 (http://ruby-doc.org/core-1.8.7/File.html#method-c-exist-3F), this method seems to be the same. So I wouldn't think this would cause any breaking changes and should just remove those pesky deprecation warnings. 

All tests are still green and I tried it on a dummy app and the deprecation warnings were removed. 