### PR TITLE
Run without warnings

### DIFF
--- a/lib/approvals/filter.rb
+++ b/lib/approvals/filter.rb
@@ -20,7 +20,7 @@ module Approvals
       when Array
         value.map { |item| censored(item) }
       when Hash
-        Hash[value.map { |key, value| [key, censored(value, key)] }]
+        Hash[value.map { |inner_key, inner_value| [inner_key, censored(inner_value, inner_key)] }]
       else
         if value.nil?
           nil

--- a/lib/approvals/namers/directory_namer.rb
+++ b/lib/approvals/namers/directory_namer.rb
@@ -1,12 +1,11 @@
 module Approvals
   module Namers
     class DirectoryNamer < RSpecNamer
-
-      def initialize(example)
-        @name = directorize example
-      end
-
       private
+
+      def name_for_example(example)
+        directorize example
+      end
 
       def directorize(example)
         approvals_path = lambda do |metadata|

--- a/lib/approvals/namers/directory_namer.rb
+++ b/lib/approvals/namers/directory_namer.rb
@@ -9,9 +9,6 @@ module Approvals
       private
 
       def directorize(example)
-        parts     = [ ]
-        metadata  = example.metadata
-
         approvals_path = lambda do |metadata|
           description = normalize metadata[:description]
           example_group = if metadata.key?(:example_group)

--- a/lib/approvals/namers/rspec_namer.rb
+++ b/lib/approvals/namers/rspec_namer.rb
@@ -1,10 +1,15 @@
 module Approvals
   module Namers
     class RSpecNamer
-
       attr_reader :name
+
       def initialize(example)
-        @name = normalize example.full_description
+        @name = name_for_example(example)
+        @output_dir = nil
+      end
+
+      def name_for_example(example)
+        normalize example.full_description
       end
 
       def normalize(string)

--- a/lib/approvals/namers/rspec_namer.rb
+++ b/lib/approvals/namers/rspec_namer.rb
@@ -15,7 +15,7 @@ module Approvals
         unless @output_dir
           begin
             @output_dir = ::RSpec.configuration.approvals_path
-          rescue NoMethodError => e
+          rescue NoMethodError
           end
           @output_dir ||= 'spec/fixtures/approvals/'
         end

--- a/lib/approvals/writers/binary_writer.rb
+++ b/lib/approvals/writers/binary_writer.rb
@@ -6,18 +6,12 @@ module Approvals
       end
 
       def initialize(opts = {})
-        self.autoregister = opts[:autoregister] || true
-        self.detect = opts[:detect]
-        self.extension = opts[:extension] || ''
-        self.write = opts[:write] || EXCEPTION_WRITER
+        @autoregister = opts[:autoregister] || true
+        @detect = opts[:detect]
+        @extension = opts[:extension] || ''
+        @write = opts[:write] || EXCEPTION_WRITER
         self.format = opts[:format] || :binary
       end
-
-      attr_accessor :autoregister
-      attr_accessor :extension
-      attr_accessor :write
-      attr_accessor :detect
-
 
       attr_reader :format
 


### PR DESCRIPTION
When using approvals in a project, running with Ruby 2.2, a number of warnings were being shown.  The various commits in this PR fix all of the warnings.

There are a couple of commits where I'm concerned about breaking existing functionality, so please review those carefully, notably the commit that fixes the redefinition of the `write` method in `BinaryWriter`.  All of the tests are still passing, though.

I really hate having to explicitly initialize an instance variable to nil when it's using the lazy-initialization pattern, but without it, there is a really annoying warning message printed for each individual spec that uses approvals.

See the individual commit comments for more details on each change.

With this version, approvals runs with no warnings in my test rspec project.