### PR TITLE
Fix line number reference when requiring erb

### DIFF
--- a/lib/approvals/approval.rb
+++ b/lib/approvals/approval.rb
@@ -1,4 +1,4 @@
-require 'erb' # It is referenced on line 56
+require 'erb' # It is referenced on line 69
 module Approvals
   class Approval
     class << self


### PR DESCRIPTION
The line number comment next to `require 'erb'` doesn't reflect the actual line number where `ERB` is referenced in the current code. The line number is now up to date.