### PR TITLE
Fix typo in README - dynamicly to dynamically

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ verify :format => :json do
 end
 ```
 
-### Exclude dynamicly changed values from json
+### Exclude dynamically changed values from json
 
 ```ruby
 Approvals.configure do |c|


### PR DESCRIPTION
Fixed minor typo in README. Had to do a double take to make sure my brain wasn't deceiving me, but Google seems to agree.