### PR TITLE
Fix bug preventing array and hash values from being filtered

### DIFF
--- a/lib/approvals/filter.rb
+++ b/lib/approvals/filter.rb
@@ -16,18 +16,18 @@ module Approvals
     end
 
     def censored value, key=nil
-      case value
-      when Array
-        value.map { |item| censored(item) }
-      when Hash
-        Hash[value.map { |inner_key, inner_value| [inner_key, censored(inner_value, inner_key)] }]
+      if value.nil?
+        nil
+      elsif key && placeholder_for(key)
+        "<#{placeholder_for(key)}>"
       else
-        if value.nil?
-          nil
-        elsif key && placeholder_for(key)
-          "<#{placeholder_for(key)}>"
-        else
-          value
+        case value
+          when Array
+            value.map { |item| censored(item) }
+          when Hash
+            Hash[value.map { |inner_key, inner_value| [inner_key, censored(inner_value, inner_key)] }]
+          else
+            value
         end
       end
     end

--- a/spec/filter_spec.rb
+++ b/spec/filter_spec.rb
@@ -74,6 +74,40 @@ describe Approvals::Filter do
     })
   end
 
+  it "filters array keys" do
+    filter = Approvals::Filter.new({foolist: /^foolist$/})
+    input = {
+      foo: 'bar124',
+      foolist: [{foo: 'bar 145', bar: 'foo'}, 'foobar'],
+      nonfoo: 'bar',
+    }
+
+    output = filter.apply(input)
+
+    expect(output).to eq({
+      foo: 'bar124',
+      foolist: '<foolist>',
+      nonfoo: 'bar',
+    })
+  end
+
+  it "filters hash keys" do
+    filter = Approvals::Filter.new({foohash: /^foohash$/})
+    input = {
+      foo: 'bar124',
+      foohash: {foo: 'bar 145', barlist: ['foo', 'bar']},
+      nonfoo: 'bar',
+    }
+
+    output = filter.apply(input)
+
+    expect(output).to eq({
+      foo: 'bar124',
+      foohash: '<foohash>',
+      nonfoo: 'bar',
+    })
+  end
+
   it "takes the last applicable filter" do
     filter = Approvals::Filter.new({foo: /^foo/, bar: /bar$/})
     input = {


### PR DESCRIPTION
The filtering of keys would not work correctly if the corresponding values for the keys were `Arrays` or `Hashes`. This was caused by the `censored` method checking for the type of the value before checking if the key matched any of the filters. By flipping around the logic and checking if the key should be filtered before checking the value's type, filtering works correctly.

Test plan: I added two new filter_spec tests to ensure this behavior is working correctly.