### PR TITLE
Install a more recent version of bundler on CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,7 @@ rvm:
   - 2.1.0
   - ruby-head
   - rbx-2
+before_install:
+  - gem update bundler
 script: bundle exec rspec spec
 cache: bundler


### PR DESCRIPTION
On some Ruby versions, an older version of bundler is installed.  Some of these older versions have a [bug](https://github.com/bundler/bundler/issues/3558) that causes our builds to fail.  Of recent note are some failures on Ruby 1.9.3 with bundler 1.7.6.

According to the [related issue on TravisCI](https://github.com/travis-ci/travis-ci/issues/3531), the solution is to add a `before_install` step to the build to update bundler.