### PR TITLE
Installer newer json gem on newer rubies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ pkg/*
 *.received.txt
 .approvals
 tmp/
+
+ext/Rakefile

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ rvm:
   - rbx
 matrix:
   allow_failures:
-    - rvm: ruby-head
     - rvm: rbx
 before_install:
   - gem update bundler

--- a/approvals.gemspec
+++ b/approvals.gemspec
@@ -19,9 +19,11 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {spec}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
+  s.extensions    << 'ext/mkrf_conf.rb'
 
   s.add_development_dependency 'rspec', '~> 3.1'
-  s.add_development_dependency 'json', '~> 1.8'
   s.add_dependency 'thor', '~> 0.18'
   s.add_dependency 'nokogiri', '~> 1.6'
+  # We also depend on the json gem, but the version we need is
+  # Ruby-version-specific. See `ext/mkrf_conf.rb`.
 end

--- a/ext/mkrf_conf.rb
+++ b/ext/mkrf_conf.rb
@@ -1,0 +1,22 @@
+require 'rubygems/dependency_installer'
+
+# This is how we can depend on a different version of the same gem for
+# different Ruby versions.
+# See https://en.wikibooks.org/wiki/Ruby_Programming/RubyGems
+
+installer = Gem::DependencyInstaller.new
+
+begin
+  if RUBY_VERSION >= '2.0'
+    installer.install 'json', '~> 2.0'
+  else
+    installer.install 'json', '~> 1.8'
+  end
+rescue
+  exit(1)
+end
+
+# Write fake Rakefile for rake since Makefile isn't used
+File.open(File.join(File.dirname(__FILE__), 'Rakefile'), 'w') do |f|
+  f.write("task :default\n")
+end


### PR DESCRIPTION
Up until now, we’ve depended on version 1.8 of the `json` gem.  But that version doesn’t support Ruby 2.4 and later, since they’ve now merged `Fixnum` and `Bignum` into `Integer`.

Version 2.0 of the gem does support the latest Ruby, but also drops support for Ruby < 2.0 which want to continue to support.

This PR allows us to install the correct version of the json gem given the Ruby version.

Note that the json gem was marked as a development dependency, but really just be a production dependency, so this PR makes that change as well.

It seems that, since the `gemspec` file is “just Ruby”, that we’d be able to put the selection code there.  But the `gemspec` is run on the system that is building the gem, and not the target system that is installing the gem, so a different approach is required.

The solution, apparently, is to create a fake extension, and have the extension install the correct version of the gem.  See https://en.wikibooks.org/wiki/Ruby_Programming/RubyGems for details.
