### PR TITLE
Use latest Rubinius

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,5 @@ before_install:
   - gem update bundler
 script: bundle exec rspec spec
 cache: bundler
+sudo: required
+dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - ruby-head
-  - rbx-3
+  - rbx
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,5 +13,3 @@ before_install:
   - gem update bundler
 script: bundle exec rspec spec
 cache: bundler
-sudo: required
-dist: trusty

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
   - 2.0.0
   - 2.1.0
   - ruby-head
-  - rbx-2
+  - rbx-3
 matrix:
   allow_failures:
     - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ rvm:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: rbx
 before_install:
   - gem update bundler
 script: bundle exec rspec spec


### PR DESCRIPTION
There don’t seem to binary versions of rbx-2 available on Travis any more, so move up to rbx-3 instead.