### PR TITLE
Upgrade the nokogiri dep to 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
-  - 2.0.0
   - 2.1.0
   - ruby-head
   - rbx

--- a/approvals.gemspec
+++ b/approvals.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.1'
   s.add_dependency 'thor', '~> 0.18'
-  s.add_dependency 'nokogiri', '~> 1.6'
+  s.add_dependency 'nokogiri', '~> 1.7'
   # We also depend on the json gem, but the version we need is
   # Ruby-version-specific. See `ext/mkrf_conf.rb`.
 end


### PR DESCRIPTION
We're relying on upstream patches of lxml in nokogiri, so would like to be able to use ~> 1.7. 

relevant backwards incompatible changes in nokogiri 1.6.8.1 -> 1.7.0: (https://github.com/sparklemotion/nokogiri/blob/v1.7.1/CHANGELOG.md)

> This release ends support for:
>
> Ruby 1.9.2, for which official support ended on 2014-07-31
> Ruby 1.9.3, for which official support ended on 2015-02-23
> Ruby 2.0.0, for which official support ended on 2016-02-24
> MacRuby, which hasn't been actively supported since 2015-01-13 (see https://github.com/MacRuby/MacRuby/commit/f76b9d6e99c18236db617e8aceb12c27d593a483)
