### PR TITLE
Update Thor to 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,27 @@
 language: ruby
 rvm:
-  - 1.9.2
-  - 1.9.3
   - 2.0.0
   - 2.1.10
-  - 2.2.9
-  - 2.3.6
-  - 2.4.3
-  - 2.5.0
+  - 2.2.10
+  - 2.3.8
+  - 2.4.8
+  - 2.5.7
+  - 2.6.5
+  - 2.7.0
   - ruby-head
   - rbx-3
 matrix:
   allow_failures:
     - rvm: rbx-3
 before_install:
-  - gem update --system
+  - |
+    r_eng="$(ruby -e 'STDOUT.write RUBY_ENGINE')";
+    rv="$(ruby -e 'STDOUT.write RUBY_VERSION')";
+    if [ "$r_eng" == "ruby" ]; then
+      if   [ "$rv" \< "2.3" ]; then gem update --system 2.7.10 --no-document
+      elif [ "$rv" \< "2.6" ]; then gem update --system --no-document --conservative
+      fi
+    fi
   - gem update bundler
 script: bundle exec rspec spec
 cache: bundler

--- a/approvals.gemspec
+++ b/approvals.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.extensions    << 'ext/mkrf_conf.rb'
 
   s.add_development_dependency 'rspec', '~> 3.1'
-  s.add_dependency 'thor', '~> 0.18'
+  s.add_dependency 'thor', '~> 1.0'
 
   if RUBY_VERSION < "2.1"
     s.add_dependency 'nokogiri', '~> 1.6.8'

--- a/lib/approvals/version.rb
+++ b/lib/approvals/version.rb
@@ -1,3 +1,3 @@
 module Approvals
-  VERSION = '0.0.24'
+  VERSION = '0.0.25'
 end


### PR DESCRIPTION
HI!

I noticed the TravisCI config contains several older Rubies and hasn't seem a commit in awhile. Is it still being maintained?

The old version of thor is preventing us from upgrading some other gems so here's a patch to upgrade it. The thorfile is pretty simple so doesn't seem like an issue.

The `before_install` code was ~~stolen~~ borrowed with ❤️ from [puma](https://github.com/puma/puma/blob/master/.travis.yml).